### PR TITLE
`create-tf-vars.sh` script enhancement

### DIFF
--- a/infra/create-tf-vars.sh
+++ b/infra/create-tf-vars.sh
@@ -48,7 +48,7 @@ COSMOS_RU=1000
 # Backup previous terraform.tfvars file is present
 if [[ -f "${tf_file}" ]]; then
   bak="${tf_file}.bak.$(date +%s)"
-  /bin/mv "${tf_file}" $bak
+  cat "${tf_file}" >| $bak
   echo "Backing up $(basename ${tf_file}) file to $bak"
 fi
 


### PR DESCRIPTION
… from examples.tfvars. Backup previous terraform.tfvars

## Type of PR

- [ ] Documentation changes
- [ ] Code changes
- [X] Infra script changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
- Add special character check with regex on `scim_Name` variable
- Doesn't use `example.tfvars` variable file. It's now a standalone script
- Uses `cat` to create backup
- `terraform.tfvars` is guaranteed to be updated by propoer redirection `>|`
- Usage remains the same.
  - In addition it can also be used like this: `scim_Name=scim0somescim190 ./create-tf-vars.sh`
  - Also it can be used from any directory.
    - For example from git root:  `./infra/create-tf-vars.sh`
    - or from `src/app` dir: `./../../infra/create-tf-vars.sh`

## Issues Closed or Referenced

- Closes #75 
- References #75 